### PR TITLE
Localize audio replicator comments and add header helper

### DIFF
--- a/Plugins/AudioReplicator/Source/AudioReplicator/Public/AudioReplicatorBPLibrary.h
+++ b/Plugins/AudioReplicator/Source/AudioReplicator/Public/AudioReplicatorBPLibrary.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "Kismet/BlueprintFunctionLibrary.h"
 #include "OpusTypes.h"
 #include "AudioReplicatorBPLibrary.generated.h"
@@ -37,8 +37,10 @@ public:
         int32 FrameMs /*=20*/,
         int32 BitrateKbps /*=32*/,
         int32 PcmSamplesTotal,
-        int32 DecPcmSamplesTotal /*=-1 если неизвестно*/,
+        int32 DecPcmSamplesTotal /*=-1 if unknown*/,
         int32 BufferBytes,
         int32 PacketCount);
 
+    UFUNCTION(BlueprintPure, Category = "AudioReplicator|Debug")
+    static FString OpusStreamHeaderToString(const FOpusStreamHeader& Header);
 };

--- a/Plugins/AudioReplicator/Source/AudioReplicator/Public/OpusTypes.h
+++ b/Plugins/AudioReplicator/Source/AudioReplicator/Public/OpusTypes.h
@@ -28,7 +28,7 @@ struct FOpusStreamHeader
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator")
     int32 FrameMs = 20;
 
-    // Необязательно, но удобно для клиентской предбуферизации/прогресса
+    // Optional but handy for client-side buffering and progress tracking.
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator")
     int32 NumPackets = 0;
 };
@@ -38,11 +38,11 @@ struct FOpusChunk
 {
     GENERATED_BODY()
 
-    // Порядковый номер фрейма (с 0)
+    // Sequential frame index starting from zero.
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator")
     int32 Index = 0;
 
-    // Один Opus-фрейм
+    // Single Opus frame payload.
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator")
     FOpusPacket Packet;
 };

--- a/Plugins/AudioReplicator/Source/AudioReplicator/Public/PcmWavUtils.h
+++ b/Plugins/AudioReplicator/Source/AudioReplicator/Public/PcmWavUtils.h
@@ -3,9 +3,21 @@
 
 namespace PcmWav
 {
-    // Читает WAV (RIFF PCM 16-bit) в PCM16 (массив int16), возвращает SR, Ch, OK
+    /**
+     * Resolve a relative or absolute WAV path against the project directories.
+     *
+     * Relative paths are interpreted as Saved/, Content/ or Project/ sub-paths.
+     * The returned value is an absolute, normalized path on disk.
+     */
+    FString ResolveProjectPath_V3(const FString& Path);
+
+    /**
+     * Load a WAV (RIFF PCM 16-bit) file and output interleaved PCM16 samples.
+     */
     bool LoadWavFileToPcm16(const FString& Path, TArray<int16>& OutPcm, int32& OutSR, int32& OutCh);
 
-    // Сохраняет PCM16 как WAV (RIFF PCM 16-bit)
+    /**
+     * Serialize interleaved PCM16 samples to a standard WAV (RIFF PCM 16-bit) file.
+     */
     bool SavePcm16ToWavFile(const FString& Path, const TArray<int16>& Pcm, int32 SR, int32 Ch);
 }


### PR DESCRIPTION
## Summary
- translate audio replicator comments and user-facing strings into English to match gamedev standards
- expose and reuse ResolveProjectPath_V3 for consistent WAV path handling
- add an Opus stream header to-string helper for debugging output

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c99106fd50833280cee90307ef86d9