### PR TITLE
Add AudioReplicator debug snapshot helpers

### DIFF
--- a/Plugins/AudioReplicator/Source/AudioReplicator/Public/AudioReplicatorBPLibrary.h
+++ b/Plugins/AudioReplicator/Source/AudioReplicator/Public/AudioReplicatorBPLibrary.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Kismet/BlueprintFunctionLibrary.h"
 #include "OpusTypes.h"
+#include "AudioReplicatorDebugTypes.h"
 #include "AudioReplicatorBPLibrary.generated.h"
 
 UCLASS()
@@ -43,4 +44,10 @@ public:
 
     UFUNCTION(BlueprintPure, Category = "AudioReplicator|Debug")
     static FString OpusStreamHeaderToString(const FOpusStreamHeader& Header);
+
+    UFUNCTION(BlueprintPure, Category = "AudioReplicator|Debug")
+    static FString FormatOutgoingDebugReport(const FAudioReplicatorOutgoingDebug& DebugInfo);
+
+    UFUNCTION(BlueprintPure, Category = "AudioReplicator|Debug")
+    static FString FormatIncomingDebugReport(const FAudioReplicatorIncomingDebug& DebugInfo);
 };

--- a/Plugins/AudioReplicator/Source/AudioReplicator/Public/AudioReplicatorComponent.h
+++ b/Plugins/AudioReplicator/Source/AudioReplicator/Public/AudioReplicatorComponent.h
@@ -2,6 +2,7 @@
 #include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
 #include "OpusTypes.h"
+#include "AudioReplicatorDebugTypes.h"
 #include "AudioReplicatorComponent.generated.h"
 
 // Blueprint delegates for monitoring replicated Opus sessions.
@@ -69,6 +70,13 @@ public:
     // Access the received data for a session (e.g., to decode and save a WAV).
     UFUNCTION(BlueprintCallable, Category = "AudioReplicator|Net")
     bool GetReceivedPackets(const FGuid& SessionId, TArray<FOpusPacket>& OutPackets, FOpusStreamHeader& OutHeader) const;
+
+    // Debug helpers that expose the current state of transfers without having to gather data manually.
+    UFUNCTION(BlueprintCallable, Category = "AudioReplicator|Debug")
+    bool GetOutgoingDebugInfo(const FGuid& SessionId, FAudioReplicatorOutgoingDebug& OutDebug) const;
+
+    UFUNCTION(BlueprintCallable, Category = "AudioReplicator|Debug")
+    bool GetIncomingDebugInfo(const FGuid& SessionId, FAudioReplicatorIncomingDebug& OutDebug) const;
 
 protected:
     virtual void BeginPlay() override;

--- a/Plugins/AudioReplicator/Source/AudioReplicator/Public/AudioReplicatorDebugTypes.h
+++ b/Plugins/AudioReplicator/Source/AudioReplicator/Public/AudioReplicatorDebugTypes.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "OpusTypes.h"
+#include "AudioReplicatorDebugTypes.generated.h"
+
+/**
+ * Per-chunk debug information that can be used to inspect replication progress.
+ */
+USTRUCT(BlueprintType)
+struct FAudioReplicatorChunkDebug
+{
+    GENERATED_BODY()
+
+    // Index of the chunk within the opus stream.
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    int32 Index = 0;
+
+    // Size of the payload for this chunk in bytes.
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    int32 SizeBytes = 0;
+
+    // True if this chunk has been sent from the owner in the current session.
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    bool bIsSent = false;
+
+    // True if this chunk has been received locally.
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    bool bIsReceived = false;
+};
+
+/**
+ * Aggregated state for an outgoing transfer that is useful during debugging.
+ */
+USTRUCT(BlueprintType)
+struct FAudioReplicatorOutgoingDebug
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    FGuid SessionId;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    FOpusStreamHeader Header;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    int32 TotalChunks = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    int32 SentChunks = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    int32 PendingChunks = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    int32 TotalBytes = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    float EstimatedDurationSec = 0.0f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    float EstimatedBitrateKbps = 0.0f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    bool bHeaderSent = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    bool bEndSent = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    int32 NextChunkIndex = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    bool bTransferComplete = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    TArray<int32> PendingChunkIndices;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    TArray<FAudioReplicatorChunkDebug> Chunks;
+};
+
+/**
+ * Aggregated state for an incoming transfer that is useful during debugging.
+ */
+USTRUCT(BlueprintType)
+struct FAudioReplicatorIncomingDebug
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    FGuid SessionId;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    FOpusStreamHeader Header;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    bool bStarted = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    bool bEnded = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    int32 ReceivedChunks = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    int32 UniqueChunks = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    int32 ExpectedChunks = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    int32 MissingChunks = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    int32 TotalBytes = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    float EstimatedDurationSec = 0.0f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    float EstimatedBitrateKbps = 0.0f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    bool bReadyToAssemble = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    TArray<int32> MissingChunkIndices;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AudioReplicator|Debug")
+    TArray<FAudioReplicatorChunkDebug> Chunks;
+};
+


### PR DESCRIPTION
## Summary
- add Blueprint-visible debug structs that capture outgoing and incoming transfer state
- expose component helpers to gather debug snapshots for a session
- add utility formatters that turn the snapshots into readable multi-line reports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc6291a1d88332809f0f0a034da17a