### PR TITLE
Expose project path utilities to Blueprints

### DIFF
--- a/Plugins/AudioReplicator/Source/AudioReplicator/Private/AudioReplicatorBPLibrary.cpp
+++ b/Plugins/AudioReplicator/Source/AudioReplicator/Private/AudioReplicatorBPLibrary.cpp
@@ -2,6 +2,8 @@
 #include "OpusCodec.h"
 #include "PcmWavUtils.h"
 #include "Chunking.h"
+#include "Misc/Paths.h"
+#include "HAL/FileManager.h"
 
 static void Int32ToInt16(const TArray<int32>& In, TArray<int16>& Out)
 {
@@ -36,6 +38,23 @@ static void UnwrapPackets(const TArray<FOpusPacket>& In, TArray<TArray<uint8>>& 
     {
         Out.Add(W.Data);
     }
+}
+
+FString UAudioReplicatorBPLibrary::ResolveProjectPath(const FString& Path)
+{
+    return PcmWav::ResolveProjectPath_V3(Path);
+}
+
+bool UAudioReplicatorBPLibrary::ProjectFileExists(const FString& Path)
+{
+    const FString FullPath = PcmWav::ResolveProjectPath_V3(Path);
+    return FPaths::FileExists(FullPath);
+}
+
+bool UAudioReplicatorBPLibrary::ProjectDirectoryExists(const FString& Path)
+{
+    const FString FullPath = PcmWav::ResolveProjectPath_V3(Path);
+    return IFileManager::Get().DirectoryExists(*FullPath);
 }
 
 bool UAudioReplicatorBPLibrary::LoadWavToPcm16(const FString& WavPath, TArray<int32>& OutPcm16, int32& OutSampleRate, int32& OutChannels)

--- a/Plugins/AudioReplicator/Source/AudioReplicator/Public/AudioReplicatorBPLibrary.h
+++ b/Plugins/AudioReplicator/Source/AudioReplicator/Public/AudioReplicatorBPLibrary.h
@@ -31,6 +31,15 @@ public:
     UFUNCTION(BlueprintCallable, Category = "AudioReplicator|Local")
     static bool TranscodeWavToOpusAndBack(const FString& InWavPath, const FString& OutWavPath, int32 Bitrate = 32000, int32 FrameMs = 20);
 
+    UFUNCTION(BlueprintPure, Category = "AudioReplicator|Paths")
+    static FString ResolveProjectPath(const FString& Path);
+
+    UFUNCTION(BlueprintPure, Category = "AudioReplicator|Paths")
+    static bool ProjectFileExists(const FString& Path);
+
+    UFUNCTION(BlueprintPure, Category = "AudioReplicator|Paths")
+    static bool ProjectDirectoryExists(const FString& Path);
+
     UFUNCTION(BlueprintCallable, Category = "AudioReplicator|Debug")
     static FString FormatAudioTestReport(
         int32 SampleRate,


### PR DESCRIPTION
## Summary
- expose the internal ResolveProjectPath helper as a Blueprint-accessible utility
- add Blueprint nodes to test for file and directory existence using the resolved project path

## Testing
- not run (Unreal build/editor execution is out of scope for this task)


------
https://chatgpt.com/codex/tasks/task_e_68cdaf493184833288b3830a8943e9b7