### PR TITLE
Expose source component in transfer end event

### DIFF
--- a/Plugins/AudioReplicator/Source/AudioReplicator/AGENTS.md
+++ b/Plugins/AudioReplicator/Source/AudioReplicator/AGENTS.md
@@ -113,7 +113,7 @@ Attach to a **replicated actor** (prefer `PlayerController`).
 
 * `OnTransferStarted(SessionId:Guid, Header:FOpusStreamHeader)`
 * `OnChunkReceived(SessionId:Guid, Chunk:FOpusChunk)`
-* `OnTransferEnded(SessionId:Guid)`
+* `OnTransferEnded(Source:AudioReplicatorComponent, SessionId:Guid)`
 
 **Blueprint Calls (Owning Client)**
 

--- a/Plugins/AudioReplicator/Source/AudioReplicator/Private/AudioReplicatorComponent.cpp
+++ b/Plugins/AudioReplicator/Source/AudioReplicator/Private/AudioReplicatorComponent.cpp
@@ -388,7 +388,7 @@ void UAudioReplicatorComponent::Multicast_EndTransfer_Implementation(const FGuid
     {
         In->bEnded = true;
     }
-    OnTransferEnded.Broadcast(SessionId);
+    OnTransferEnded.Broadcast(this, SessionId);
 }
 
 // No replicated properties yet, but keep the hook for future use

--- a/Plugins/AudioReplicator/Source/AudioReplicator/Public/AudioReplicatorComponent.h
+++ b/Plugins/AudioReplicator/Source/AudioReplicator/Public/AudioReplicatorComponent.h
@@ -6,9 +6,11 @@
 #include "AudioReplicatorComponent.generated.h"
 
 // Blueprint delegates for monitoring replicated Opus sessions.
+class UAudioReplicatorComponent;
+
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnOpusTransferStarted, FGuid, SessionId, FOpusStreamHeader, Header);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnOpusChunkReceived, FGuid, SessionId, FOpusChunk, Chunk);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnOpusTransferEnded, FGuid, SessionId);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnOpusTransferEnded, UAudioReplicatorComponent*, Source, FGuid, SessionId);
 
 USTRUCT()
 struct FOutgoingTransfer


### PR DESCRIPTION
## Summary
- extend the OnTransferEnded delegate to include the source component pointer
- update the multicast broadcast to pass the component instance
- refresh plugin documentation to reflect the new event signature

## Testing
- not run (not allowed in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68fbdb3a74848332a25cb306f21482a1